### PR TITLE
[Back] 채팅 예외 필터, 게이트웨이 파일 리팩토링

### DIFF
--- a/backend/src/models/chat/entities/channelUser.entity.ts
+++ b/backend/src/models/chat/entities/channelUser.entity.ts
@@ -34,7 +34,7 @@ export class ChannelUser {
   @JoinColumn({ name: 'channel_id' })
   channel: ChatChannel;
 
-  @ManyToOne(() => User, (user) => user.joinChannels, { eager: false })
+  @ManyToOne(() => User, (user) => user.joinChannels, { eager: true })
   @JoinColumn({ name: 'user_id' })
   user: User;
 }

--- a/backend/src/models/chat/socket/chatSocket.gateway.ts
+++ b/backend/src/models/chat/socket/chatSocket.gateway.ts
@@ -108,7 +108,6 @@ export class ChatSocketGateway implements OnGatewayConnection, OnGatewayDisconne
     
     const adminId = this.getUserIdBySocketId(socket.id);
     const userSocket = this.getSocketIdByUserId(kickDto.user_id);
-    console.log("\n\n\n\nadminId = " + adminId + "     userSocket = "+ userSocket)
     return this.chatSocketService.kickUser(this.server, adminId, kickDto, userSocket);
   }
 

--- a/backend/src/models/chat/socket/chatSocket.gateway.ts
+++ b/backend/src/models/chat/socket/chatSocket.gateway.ts
@@ -31,7 +31,7 @@ export class ChatSocketGateway implements OnGatewayConnection, OnGatewayDisconne
   
 
   async handleConnection(@ConnectedSocket() socket: Socket): Promise<void> {
-    const { user_id, channel_id } = socket.handshake.query; //string | string[] 으로 들어옴
+    const { user_id, channel_id } = socket.handshake.query; 
     socket.data.user = user_id as string;
     socket.data.channel = channel_id as string;
     try {
@@ -60,186 +60,53 @@ export class ChatSocketGateway implements OnGatewayConnection, OnGatewayDisconne
   @SubscribeMessage('enter-chat')
   async handleSetClientDataEvent(@ConnectedSocket() socket: Socket, @MessageBody() dto : ChannelIdDto){
 
-    const user_id = this.getUserIdBySocketId(socket.id);
-    if (!user_id || !(await this.chatSocketService.checkChannelUser(dto.channel_id, user_id)))
-      throw new SocketException('Forbidden', `권한이 없습니다!`);
-    
-    try {
-      socket.join(`chat_${dto.channel_id}`);
-      socket.broadcast
-       .to(`chat_${dto.channel_id}`)
-       .emit('message', { message: `${user_id} 유저가 들어왔습니다.` });
-      this.logger.log(`Socket connected: ${user_id}`);  
-
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
+    const userId = this.getUserIdBySocketId(socket.id);
+    return this.chatSocketService.enterChatRoom(socket, dto.channel_id, userId);
   }
   
   @SubscribeMessage('leave-chat')
   async handleLeaveRoom(@ConnectedSocket() socket: Socket, @MessageBody() dto : ChannelIdDto) {
 
-    const user_id = this.getUserIdBySocketId(socket.id);
-    if (!user_id || !(await this.chatSocketService.checkChannelUser(dto.channel_id, user_id)))
-      throw new SocketException('Forbidden', `권한이 없습니다!`);
-    try {
-      socket.leave(`chat_${dto.channel_id}`); // leave room
-      socket.broadcast
-      .to(`chat_${dto.channel_id}`)
-      .emit('message', { message: `${user_id}가 나갔습니다.` });
-
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
+    const userId = this.getUserIdBySocketId(socket.id);
+    return this.chatSocketService.leaveChatRoom(socket, dto.channel_id, userId);
   }
-
 
   @SubscribeMessage('message-chat')
   async handleChatEvent(@ConnectedSocket() socket: Socket, @MessageBody() md: MessageDto) {
-    this.logger.log(md.channel_id + "  :" +md.message + " ");
-    let dmUser;
-    const user_id = this.getUserIdBySocketId(socket.id);
-    if (!user_id)
-      throw new SocketException('Forbidden', `권한이 없습니다!`);
 
-    const channel = await this.chatSocketService.getChannelType(md.channel_id);
-    if (!channel) {
-      throw new SocketException('BadRequest', `채널을 찾을 수 없습니다!`);
-    } else if (channel.type === ChannelType.DM && !(dmUser = await this.chatSocketService.getDmUser(md.channel_id, user_id))) {
-      throw new SocketException('BadRequest', `디엠 유저를 찾을 수 없습니다!`);
-    } else if (channel.type !== ChannelType.DM && !await this.chatSocketService.checkChannelUser(md.channel_id, user_id)) {
-      throw new SocketException('BadRequest', `채팅 유저를 찾을 수 없습니다!`);
-    }
-
-    if (await this.chatSocketService.checkMuteUser(md.channel_id, user_id)) {
-      throw new SocketException('Forbidden', `뮤트 상태입니다!`);
-    }
- 
-    try {
-      await this.chatSocketService.createMessageLog(user_id, md, channel.type);
-      if (channel.type === ChannelType.DM) {
-        await this.chatSocketService.updateDmUser(dmUser);
-      }
-      socket.broadcast
-      .to(`chat_${md.channel_id}`)
-      .emit('chat', md);
-
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
-  
+    const userId = this.getUserIdBySocketId(socket.id);
+    return this.chatSocketService.sendChatMessage(socket, userId, md);
   }
 
   @SubscribeMessage('mute-chat')
   async muteChannelUser(@ConnectedSocket() socket: Socket, @MessageBody() muteDto: toggleTimeDto) {
-    const {user_id, channel_id} = muteDto;
+
     const adminId = this.getUserIdBySocketId(socket.id);
-
-    if (!adminId ||
-      !(await this.chatSocketService.checkAdminUser(channel_id, adminId)) ||
-      !(await this.chatSocketService.checkChannelUserRole(channel_id, user_id)))
-        throw new SocketException('Forbidden', `권한이 없습니다!`);
-
-    try {
-      const muted = await this.chatSocketService.checkMuteUser(channel_id, user_id);
-    
-      if (muted) {
-        await this.chatSocketService.unmuteUser(channel_id, user_id);
-        this.server.to(`chat_${channel_id}`).emit('mute', { message: `${user_id} 가 뮤트 해제 되었습니다.` });
-        
-      } else {
-        if (muteDto.end_at === null) {
-          throw new SocketException('BadRequest', `뮤트 해제 시간을 추가하세요!`);
-        }
-        const mute = await this.chatSocketService.muteUser(muteDto);
-        if (!mute)
-          throw new SocketException('InternalServerError', `뮤트 실패!`);
-        this.server.to(`chat_${channel_id}`).emit('mute', { message: `${user_id} 가 뮤트 되었습니다.` });
-      }
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
+    return this.chatSocketService.muteUser(this.server, adminId, muteDto);
   }
 
   @SubscribeMessage('ban-chat')
   async banChannelUser(@ConnectedSocket() socket: Socket, @MessageBody() banDto: toggleTimeDto) {
-    const {user_id, channel_id} = banDto;
 
     const adminId = this.getUserIdBySocketId(socket.id);
-    if (!adminId ||
-      !(await this.chatSocketService.checkAdminUser(channel_id, adminId)) ||
-      !(await this.chatSocketService.checkChannelUserRole(channel_id, user_id)))
-        throw new SocketException('Forbidden', `권한이 없습니다!`);
-    try {
-      const banned = await this.chatSocketService.checkBanUser(channel_id, user_id);
-
-      if (banned) {
-        throw new SocketException('Conflict', `이 유저는 이미 밴 상태입니다!`);
-      } else {
-        const banned = await this.chatSocketService.banUser(banDto);
-        if (!banned)
-          throw new SocketException('InternalServerError', `밴 실패!`);
-
-        await this.chatSocketService.kickUser(channel_id, user_id);
-        const userSocket = this.getSocketIdByUserId(user_id);
-        if (userSocket)
-         this.server.in(userSocket).socketsLeave(`chat_${channel_id}`);
-        
-        this.server.to(`chat_${channel_id}`).emit('ban', { message: `${user_id} 가 밴 되었습니다.` });
-      }
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
+    const userSocket = this.getSocketIdByUserId(banDto.user_id);
+    return this.chatSocketService.banUser(this.server, adminId, banDto, userSocket);
   }
 
   @SubscribeMessage('unban-chat')
   async unbanChannelUser(@ConnectedSocket() socket: Socket, @MessageBody() unbanDto: toggleDto) {
-    const {user_id, channel_id} = unbanDto;
+
     const adminId = this.getUserIdBySocketId(socket.id);
-    if (!adminId ||
-      !(await this.chatSocketService.checkAdminUser(channel_id, adminId)))
-        throw new SocketException('Forbidden', `권한이 없습니다!`);
-    
-    try {
-      const banned = await this.chatSocketService.checkBanUser(channel_id, user_id);
-      if (banned) {
-        await this.chatSocketService.unbanUser(channel_id, user_id);
-        this.server.to(`chat_${channel_id}`).emit('ban', { message: `${user_id} 가 밴 해제 되었습니다.` });
-      }  else {
-        throw new SocketException('Conflict', `밴 유저가 아닙니다!`);
-      }
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
+    return this.chatSocketService.unBanUser(this.server, adminId, unbanDto);
   }
 
 
   @SubscribeMessage('kick-chat')
   async kickChannelUser(@ConnectedSocket() socket: Socket, @MessageBody() kickDto: toggleDto) {
-    const {user_id, channel_id} = kickDto;
-
+    
     const adminId = this.getUserIdBySocketId(socket.id);
-    if (!adminId ||
-      !(await this.chatSocketService.checkAdminUser(channel_id, adminId)) ||
-      !(await this.chatSocketService.checkChannelUserRole(channel_id, user_id)))
-        return { error: 'No permission!' };
-    try {
-      await this.chatSocketService.kickUser(channel_id, user_id);
-     const userSocket = this.getSocketIdByUserId(user_id);
-     if (userSocket)
-      this.server.in(userSocket).socketsLeave(`chat_${channel_id}`);
-
-      this.server.to(`chat_${channel_id}`).emit(`kick`,  { message: `${user_id} 가 강제 퇴장 되었습니다.` });
-    } catch (error) {
-      this.logger.log(error)
-      throw new SocketException('InternalServerError', `${error.message}`);
-    }
+    const userSocket = this.getSocketIdByUserId(kickDto.user_id);
+    return this.chatSocketService.kickUser(this.server, adminId, kickDto, userSocket);
   }
 
   getSocketIdByUserId(userId: number) {

--- a/backend/src/models/chat/socket/chatSocket.gateway.ts
+++ b/backend/src/models/chat/socket/chatSocket.gateway.ts
@@ -42,10 +42,12 @@ export class ChatSocketGateway implements OnGatewayConnection, OnGatewayDisconne
       } else {
         this.users.push({ userId: parseInt(user_id as string), socketId: socket.id });
       }
+      this.logger.log(`Socket connected: ${user_id}'s ${socket.id}`);
     } catch (error) {
       socket.disconnect();
     }
   }
+
 
   async handleDisconnect(@ConnectedSocket() socket: Socket): Promise<void> {
     const { user_id } = socket.data.user
@@ -106,6 +108,7 @@ export class ChatSocketGateway implements OnGatewayConnection, OnGatewayDisconne
     
     const adminId = this.getUserIdBySocketId(socket.id);
     const userSocket = this.getSocketIdByUserId(kickDto.user_id);
+    console.log("\n\n\n\nadminId = " + adminId + "     userSocket = "+ userSocket)
     return this.chatSocketService.kickUser(this.server, adminId, kickDto, userSocket);
   }
 

--- a/backend/src/models/chat/socket/chatSocket.gateway.ts
+++ b/backend/src/models/chat/socket/chatSocket.gateway.ts
@@ -46,7 +46,7 @@ export class ChatSocketGateway implements OnGatewayConnection, OnGatewayDisconne
   }
 
   async handleDisconnect(@ConnectedSocket() socket: Socket): Promise<void> {
-    const { user_id } = socket.data
+    const { user_id } = socket.data.user
     const userIndex = this.users.findIndex((u) => u.userId.toString() === user_id);
     if (userIndex >= 0) {
       this.users.splice(userIndex, 1);

--- a/backend/src/models/chat/socket/services/chatSocket.service.ts
+++ b/backend/src/models/chat/socket/services/chatSocket.service.ts
@@ -1,10 +1,11 @@
-import { Injectable, InternalServerErrorException, NotFoundException, UnauthorizedException } from '@nestjs/common';
+import { Injectable, InternalServerErrorException, Logger, NotFoundException, UnauthorizedException } from '@nestjs/common';
 import { ChannelBanList, ChannelMuteList, ChannelUser, ChannelUserRoles, DmChannel, MessageLog } from '../../entities';
 import { ChannelType, ChatChannel } from '../../entities/chatChannel.entity';
 import { DataSource, Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
-import { MessageDto, toggleTimeDto } from '../../dto/socket.dto';
-import { date } from 'joi';
+import { MessageDto, toggleDto, toggleTimeDto } from '../../dto/socket.dto';
+import {SocketException, SocketExceptionFilter} from '../socket.filter';
+import { Server, Socket } from 'socket.io';
 
 
 @Injectable()
@@ -29,8 +30,194 @@ export class ChatSocketService {
     private muteRepository: Repository<ChannelMuteList>,
 
     private dataSource: DataSource
+
   
   ) {}
+
+  async enterChatRoom(socket: Socket, channel_id: number, user_id: number) {
+    
+    let userNickname;
+    
+    if (!user_id || !(userNickname = await this.getChannelUserName(channel_id, user_id)))
+      throw new SocketException('Forbidden', `권한이 없습니다!`);
+    
+    try {
+      socket.join(`chat_${channel_id}`);
+      socket.broadcast
+       .to(`chat_${channel_id}`)
+       .emit('message', { message: `${userNickname} 가 들어왔습니다.` });
+      //this.logger.log(`Socket connected: ${user_id}`);  
+
+    } catch (error) {
+      //this.logger.log(error)
+      throw new SocketException('InternalServerError', `${error.message}`);
+    }
+}
+
+async leaveChatRoom(socket: Socket, channel_id: number, user_id: number) {
+  
+  let userNickname;
+  
+  if (!user_id || !(userNickname = await this.getChannelUserName(channel_id, user_id)))
+    throw new SocketException('Forbidden', `권한이 없습니다!`);
+  try {
+    socket.leave(`chat_${channel_id}`); // leave room
+    socket.broadcast
+    .to(`chat_${channel_id}`)
+    .emit('message', { message: `${userNickname} 가 나갔습니다.`});
+
+  } catch (error) {
+    // this.logger.log(error)
+    throw new SocketException('InternalServerError', `${error.message}`);
+  }
+}
+
+
+async sendChatMessage(socket: Socket, user_id: number, md: MessageDto) {
+  
+  if (!user_id)
+    throw new SocketException('Forbidden', `권한이 없습니다!`);
+
+  let dmUser;
+  const channel = await this.getChannelType(md.channel_id);
+  if (!channel) {
+    throw new SocketException('BadRequest', `채널을 찾을 수 없습니다!`);
+  } else if (channel.type === ChannelType.DM && !(dmUser = await this.getDmUser(md.channel_id, user_id))) {
+    throw new SocketException('BadRequest', `디엠 유저를 찾을 수 없습니다!`);
+  } else if (channel.type !== ChannelType.DM && !await this.checkChannelUser(md.channel_id, user_id)) {
+    throw new SocketException('BadRequest', `채팅 유저를 찾을 수 없습니다!`);
+  }
+
+  if (await this.checkMuteUser(md.channel_id, user_id)) {
+    throw new SocketException('Forbidden', `뮤트 상태입니다!`);
+  }
+
+  try {
+    await this.createMessageLog(user_id, md, channel.type);
+    if (channel.type === ChannelType.DM) {
+      await this.updateDmUser(dmUser);
+    }
+    socket.broadcast
+    .to(`chat_${md.channel_id}`)
+    .emit('chat', md);
+
+  } catch (error) {
+    // this.logger.log(error)
+    throw new SocketException('InternalServerError', `${error.message}`);
+  }
+}
+
+async muteUser(server: Server, adminId: number, muteDto: toggleTimeDto ) {
+
+  const {user_id, channel_id} = muteDto;
+
+  if (!adminId ||
+    !(await this.checkAdminUser(channel_id, adminId)) ||
+    !(await this.checkChannelUserRole(channel_id, user_id)))
+      throw new SocketException('Forbidden', `권한이 없습니다!`);
+
+  try {
+    const nickname = await this.getChannelUserName(channel_id, user_id)
+    const muted = await this.checkMuteUser(channel_id, user_id);
+
+    if (muted) {
+      await this.unmuteUser(channel_id, user_id);
+      server.to(`chat_${channel_id}`).emit('mute', { message: `${nickname} 가 뮤트 해제 되었습니다.` });
+    } else {
+      if (muteDto.end_at === null) {
+        throw new SocketException('BadRequest', `뮤트 해제 시간을 추가하세요!`);
+      }
+      const mute = await this.createMuteUser(muteDto);
+      if (!mute) {
+        throw new SocketException('InternalServerError', `뮤트 실패!`);
+      }
+      server.to(`chat_${channel_id}`).emit('mute', { message: `${nickname} 가 뮤트 되었습니다.` });
+    }
+  } catch (error) {
+    // this.logger.log(error)
+    throw new SocketException('InternalServerError', `${error.message}`);
+  }
+}
+
+async banUser(server: Server, adminId: number, banDto: toggleTimeDto, userSocket: string) {
+
+  const {user_id, channel_id} = banDto;
+
+  if (!adminId ||
+    !(await this.checkAdminUser(channel_id, adminId)) ||
+    !(await this.checkChannelUserRole(channel_id, user_id)))
+      throw new SocketException('Forbidden', `권한이 없습니다!`);
+  try {
+    const banned = await this.checkBanUser(channel_id, user_id);
+
+    if (banned) {
+      throw new SocketException('Conflict', `이 유저는 이미 밴 상태입니다!`);
+    } else {
+      const banned = await this.createBanUser(banDto);
+      if (!banned) {
+        throw new SocketException('InternalServerError', `밴 실패!`);
+      }
+      await this.deleteChannlUser(channel_id, user_id);
+
+      if (userSocket) {
+        server.in(userSocket).socketsLeave(`chat_${channel_id}`);
+      }
+      const nickname = await this.getChannelUserName(channel_id, user_id) 
+      server.to(`chat_${channel_id}`).emit('ban', { message: `${nickname} 가 밴 되었습니다.` });
+    }
+  } catch (error) {
+    // this.logger.log(error)
+    throw new SocketException('InternalServerError', `${error.message}`);
+  }
+}
+
+async unBanUser(server: Server, adminId: number, unbanDto: toggleDto) {
+
+  const {user_id, channel_id} = unbanDto;
+
+  if (!adminId ||
+    !(await this.checkAdminUser(channel_id, adminId)))
+      throw new SocketException('Forbidden', `권한이 없습니다!`);
+  
+  try {
+    const banned = await this.checkBanUser(channel_id, user_id);
+    if (banned) {
+      await this.releaseBanUser(channel_id, user_id);
+      const nickname = await this.getChannelUserName(channel_id, user_id) 
+      server.to(`chat_${channel_id}`).emit('ban', { message: `${nickname} 가 밴 해제 되었습니다.` });
+    }  else {
+      throw new SocketException('Conflict', `밴 유저가 아닙니다!`);
+    }
+  } catch (error) {
+    // this.logger.log(error)
+    throw new SocketException('InternalServerError', `${error.message}`);
+  }
+}
+
+async kickUser(server: Server, adminId: number, kickDto: toggleDto, userSocket: string) {
+
+  const {user_id, channel_id} = kickDto;
+
+  if (!adminId ||
+    !(await this.checkAdminUser(channel_id, adminId)) ||
+    !(await this.checkChannelUserRole(channel_id, user_id)))
+      return { error: 'No permission!' };
+  try {
+    await this.deleteChannlUser(channel_id, user_id);
+
+   if (userSocket)
+    server.in(userSocket).socketsLeave(`chat_${channel_id}`);
+  
+    let nickname;
+    if (nickname = await this.getChannelUserName(channel_id, user_id))
+      server.to(`chat_${channel_id}`).emit(`kick`,  { message: `${nickname} 가 강제 퇴장 되었습니다.` });
+  } catch (error) {
+    // this.logger.log(error)
+    throw new SocketException('InternalServerError', `${error.message}`);
+  }
+}
+
+
 
   async createMessageLog(user_id: number, md: MessageDto, type: ChannelType) :Promise<MessageLog> {
     const newLog = this.messageLogRepository.create({
@@ -52,7 +239,7 @@ export class ChatSocketService {
     .update({first_user_id: dmUser.first_user_id, second_user_id:dmUser.second_user_id}, {updated_at: new Date()});
   }
 
-  async muteUser(muteDto: toggleTimeDto) :Promise<ChannelMuteList> {
+  async createMuteUser(muteDto: toggleTimeDto) :Promise<ChannelMuteList> {
     const muteUser = this.muteRepository.create({
       user_id: muteDto.user_id,
       channel_id: muteDto.channel_id,
@@ -62,7 +249,7 @@ export class ChatSocketService {
     return muteUser;
   }
 
-  async banUser(banDto: toggleTimeDto) :Promise<ChannelBanList> {
+  async createBanUser(banDto: toggleTimeDto) :Promise<ChannelBanList> {
     const banUser = this.banRepository.create({
       user_id: banDto.user_id,
       channel_id: banDto.channel_id,
@@ -72,7 +259,7 @@ export class ChatSocketService {
     return banUser;
   }
 
-  async kickUser(channel_id: number, user_id: number) {
+  async deleteChannlUser(channel_id: number, user_id: number) {
     return await this.channelUserRepository.softDelete({channel_id, user_id});
   }
 
@@ -82,7 +269,7 @@ export class ChatSocketService {
       throw new NotFoundException(`Cant't find mute id ${user_id} in ${channel_id}`)
   }
 
-  async unbanUser(channel_id: number, user_id: number) {
+  async releaseBanUser(channel_id: number, user_id: number) {
     const result = await this.banRepository.delete({channel_id, user_id});
     if (result.affected === 0)
       throw new NotFoundException(`Cant't find ban id ${user_id} in ${channel_id}`)
@@ -108,14 +295,22 @@ export class ChatSocketService {
     return false;
   }
 
-  async checkChannelUser(channel_id: number, user_id: number) :Promise <boolean>   {
-    const chatUser = await this.channelUserRepository
-    .findOne({select: {user_id:true}, where: {channel_id, user_id}});
-  //const chatUser = await this.channelUserRepository.findOne({where: {user_id, channel_id}});
+  async getChannelUserName(channel_id: number, user_id: number)    {
+    const chatUser = await this.channelUserRepository.findOne({where: {channel_id, user_id}});
+    if (chatUser)
+      return chatUser.user.nickname;
+    return null;
+  }
+
+
+  async checkChannelUser(channel_id: number, user_id: number) :Promise<boolean>   {
+    const chatUser = await this.channelUserRepository.findOne({where: {channel_id, user_id}});
     if (chatUser)
       return true;
     return false;
   }
+
+
 
   async checkChannelUserRole(channel_id: number, user_id: number) :Promise <boolean>   {
     const chatUser = await this.channelUserRepository.findOne({where: {channel_id, user_id, role: ChannelUserRoles.USER}});
@@ -126,7 +321,6 @@ export class ChatSocketService {
   
   async checkAdminUser(channel_id: number, user_id: number) : Promise <boolean> {
     const channelUser = await this.channelUserRepository.findOne({where: {user_id, channel_id}});
-    console.log(channelUser)
     if (!channelUser || channelUser.role === ChannelUserRoles.USER)
       return false;
     return true;

--- a/backend/src/models/chat/socket/socket.filter.ts
+++ b/backend/src/models/chat/socket/socket.filter.ts
@@ -1,0 +1,31 @@
+import { ArgumentsHost, Catch, ExceptionFilter, HttpException } from "@nestjs/common";
+import { BaseWsExceptionFilter, WsException } from "@nestjs/websockets";
+import { Socket } from 'socket.io';
+
+export type ExceptionStatus =
+    | 'BadRequest'
+    | 'Unauthorized'
+    | 'Forbidden'
+    | 'NotFound'
+    | 'Conflict'
+    | 'InternalServerError';
+
+export class SocketException extends WsException {
+  constructor(status: ExceptionStatus, message: string) {
+      super({ status, message });
+  }
+}
+
+@Catch(SocketException)
+export class SocketExceptionFilter extends BaseWsExceptionFilter {
+    catch(exception: SocketException, host: ArgumentsHost) {
+
+        const socket:Socket = host.getArgByIndex(0);
+        const error = exception.getError();
+
+        socket.emit('error', {
+            status: `${Object.values(error)[0]}`,
+            message: `${Object.values(error)[1]}`
+          });
+    }
+}


### PR DESCRIPTION
##

### 1. 채팅 gateway.ts 로직 리펙토링

#### 문제
- 기존 gateway.ts와 socketService.ts 파일들이 역할의 구분없이 섞여있는 코드

#### 해결
- 기존 채팅 gateway.ts 로직들을 모두 service 로 연동시켜, gateway 파일은 api 요청의 컨트롤러 파일처럼 라우터의 역할로 변경.

##

### 2. 소켓 예외 필터 추가


#### 문제
- 채팅 gateway 파일 내부 이벤트에서 발생하는 exception 은 http 에서 제공하는 Exception 이 적용되어 response 되지 않는 문제

#### 해결
- 소켓 통신 중 예외처리가 발생하면 response 방식처럼 error emit 을 통해 해당 소켓 클라이언트에게 에러 상황을 알리기



#### 코드 설명
0. throw 시 받는 에러 상태를 http status 처럼 사용하기 위햐 커스텀 status 만들어주기
```
export type ExceptionStatus =
    | 'BadRequest'
    | 'Unauthorized'
    | 'Forbidden'
    | 'NotFound'
    | 'Conflict'
    | 'InternalServerError';

export class SocketException extends WsException {
  constructor(status: ExceptionStatus, message: string) {
      super({ status, message });
  }
}
```

1.  BaseWsExceptionFilter 를 상속 받는 SocketExceptionFilter 선언한 뒤 @Catch 에 status class 받아오기
```
@Catch(SocketException)
export class SocketExceptionFilter extends BaseWsExceptionFilter {

}
```

2. gateway에 connect 되어서 이벤트를 요청했다가 throw 된 소켓을 찾아와 emit 해주기.
**이때 클라이언트는 이미 'error' 이벤트를 listen 하고 있는 상태여야 함!**

```
@Catch(SocketException)
export class SocketExceptionFilter extends BaseWsExceptionFilter {
    catch(exception: SocketException, host: ArgumentsHost) {
        const socket:Socket = host.getArgByIndex(0);
        const error = exception.getError();

        socket.emit('error', {
            status: `${Object.values(error)[0]}`,
            message: `${Object.values(error)[1]}`
          });
    }
}
```


4. gateway.ts 파일 내부 게이트웨이에 @UseFilters(new SocketExceptionFilter())  데코레이터 달기
```
@UseFilters(new SocketExceptionFilter()) 
@WebSocketGateway({
  cors: {
    origin: '*',
  },
})
```

5. event 내부에서 throw 할 때 SocketException 이름으로 요청하면 자동으로 필터 로직이 호출되어 ERROR emit 됨

```
 } catch (error) {
      this.logger.log(error)
      throw new SocketException('InternalServerError', `${error.message}`);
    }
```

### PostMan 테스트 결과

- 존재하지 않는 999번의 channel_id 를 보낸다 -> 에러를 발생

<img width="500" alt="image" src="https://user-images.githubusercontent.com/69143394/230573867-dd270b6c-d888-4959-89e9-c83357e3a1ab.png">




##