### PR TITLE
[back] feat: user search

### DIFF
--- a/backend/src/models/user/api/dtos/searchUserRes.dto.ts
+++ b/backend/src/models/user/api/dtos/searchUserRes.dto.ts
@@ -6,12 +6,12 @@ export class SearchedUser {
     this.user_id = user.user_id;
     this.nickname = user.nickname;
     this.profile_url = user.profile_url;
-    this.status = user.relatedOf[0]?.status || RelationStatus.NONE;
+    this.relationWithMe = user.relatedOf[0]?.status || RelationStatus.NONE;
   }
   user_id: number;
   nickname: string;
   profile_url: string;
-  status: RelationStatus;
+  relationWithMe: RelationStatus;
 }
 
 export class SearchUserResDto {

--- a/backend/src/models/user/api/dtos/searchUserRes.dto.ts
+++ b/backend/src/models/user/api/dtos/searchUserRes.dto.ts
@@ -1,0 +1,19 @@
+import { RelationStatus } from '../../../../common/enums/relationStatus.enum';
+import { User } from '../../entities';
+
+export class SearchedUser {
+  constructor(user: User) {
+    this.user_id = user.user_id;
+    this.nickname = user.nickname;
+    this.profile_url = user.profile_url;
+    this.status = user.relatedOf[0]?.status || RelationStatus.NONE;
+  }
+  user_id: number;
+  nickname: string;
+  profile_url: string;
+  status: RelationStatus;
+}
+
+export class SearchUserResDto {
+  users: SearchedUser[];
+}

--- a/backend/src/models/user/api/services/user.service.spec.ts
+++ b/backend/src/models/user/api/services/user.service.spec.ts
@@ -418,7 +418,8 @@ describe('UserService', () => {
           user_id: savedUsers[i].user_id,
           nickname: savedUsers[i].nickname,
           profile_url: savedUsers[i].profile_url,
-          status: i % 3 === 1 ? RelationStatus.BLOCK : i % 3 === 2 ? RelationStatus.FRIEND : RelationStatus.NONE,
+          relationWithMe:
+            i % 3 === 1 ? RelationStatus.BLOCK : i % 3 === 2 ? RelationStatus.FRIEND : RelationStatus.NONE,
         });
       }
     });

--- a/backend/src/models/user/api/services/user.service.ts
+++ b/backend/src/models/user/api/services/user.service.ts
@@ -128,9 +128,11 @@ export class UserService {
       relations: ['relatedOf'],
     });
     return {
-      users: foundUsers.map((user: User) => {
-        return new SearchedUser(user);
-      }),
+      users: foundUsers
+        .map((user: User) => {
+          return new SearchedUser(user);
+        })
+        .filter((user: SearchedUser) => user.user_id !== userId),
     };
   }
 }

--- a/backend/src/models/user/api/services/user.service.ts
+++ b/backend/src/models/user/api/services/user.service.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../../entities';
-import { QueryFailedError, Repository } from 'typeorm';
+import { Like, QueryFailedError, Repository } from 'typeorm';
 import {
   BadRequestException,
   ConflictException,
@@ -12,6 +12,7 @@ import { CreateUserReqDto, GetUserResDto, UpdateUserReqDto, UpdateUserResDto } f
 import { GetUserSettingResDto } from '../dtos/getUserSettingRes.dto';
 import { JwtPayloadInterface } from '../../../../common/interfaces/JwtUser.interface';
 import { VerifyNicknameResponseDto } from '../dtos/verifyNickname.dto';
+import { SearchedUser, SearchUserResDto } from '../dtos/searchUserRes.dto';
 
 @Injectable()
 export class UserService {
@@ -113,6 +114,23 @@ export class UserService {
     });
     return {
       isDuplicate: !!user,
+    };
+  }
+
+  async searchUser(userId: number, nickname: string): Promise<SearchUserResDto> {
+    const user: User = await this.userRepository.findOne({ where: { user_id: userId } });
+    if (!user) throw new UnauthorizedException('invalid user (session is not valid)');
+    const foundUsers: User[] = await this.userRepository.find({
+      where: {
+        nickname: Like(`%${nickname}%`),
+      },
+      select: ['user_id', 'nickname', 'profile_url'],
+      relations: ['relatedOf'],
+    });
+    return {
+      users: foundUsers.map((user: User) => {
+        return new SearchedUser(user);
+      }),
     };
   }
 }

--- a/backend/src/models/user/api/user.controller.ts
+++ b/backend/src/models/user/api/user.controller.ts
@@ -10,6 +10,7 @@ import { TokenDto } from '../../../auth/otp/token.dto';
 import { GetUserSettingResDto } from './dtos/getUserSettingRes.dto';
 import { JwtPayloadInterface } from '../../../common/interfaces/JwtUser.interface';
 import { VerifyNicknameResponseDto } from './dtos/verifyNickname.dto';
+import { SearchUserResDto } from './dtos/searchUserRes.dto';
 
 @Controller('user')
 export class UserController {
@@ -72,5 +73,14 @@ export class UserController {
   @Delete('/me/2fa')
   async deactivateTwoFactor(@GetGuardData() data: JwtPayloadInterface, @Body() tokenDto: TokenDto): Promise<void> {
     return this.twoFactorService.deactivateUserTwoFactor(data.user_id, tokenDto.token);
+  }
+
+  @UseGuards(JwtGuard)
+  @Get('/search/:searchString')
+  async searchUser(
+    @GetGuardData() data: JwtPayloadInterface,
+    @Param('searchString') searchString: string
+  ): Promise<SearchUserResDto> {
+    return this.userService.searchUser(data.user_id, searchString);
   }
 }

--- a/backend/src/models/user/api/user.controller.ts
+++ b/backend/src/models/user/api/user.controller.ts
@@ -1,5 +1,5 @@
-import { Body, Controller, Delete, Get, Param, Post, Put, Res, UseGuards } from '@nestjs/common';
-import { GetUserResDto, CreateUserReqDto, UpdateUserReqDto, UpdateUserResDto } from './dtos';
+import { Body, Controller, Delete, Get, Param, ParseIntPipe, Post, Put, Res, UseGuards } from '@nestjs/common';
+import { CreateUserReqDto, GetUserResDto, UpdateUserReqDto, UpdateUserResDto } from './dtos';
 import { UserService } from './services';
 import { UserCreationGuard } from '../../../common/guards/userCreation/userCreation.guard';
 import { JwtGuard } from '../../../common/guards/jwt/jwt.guard';
@@ -18,7 +18,10 @@ export class UserController {
 
   @UseGuards(JwtGuard)
   @Get('/:userid')
-  async getUser(@Param('userid') userid: number): Promise<GetUserResDto> {
+  async getUser(
+    @Param('userid', new ParseIntPipe({}))
+    userid: number
+  ): Promise<GetUserResDto> {
     return this.userService.getUser(userid);
   }
 


### PR DESCRIPTION
명세 참고, 테스트 완료

# /api/user/search/:nickname

## Method

`GET`

## Authentication

- 로그인이 된 세션에만 허용

## 역할

- 해당 `%nickname%`을 가진 모든 사용자 반환 (본인 제외)
    - like 이기 때문에 `nickname`이 포함되면 모두 검색됩니다.

### REQUEST

- `GET /api/user/search/${검색할 사용자 닉네임}`
- ⚠️ 검색할 사용자 이름 부분은 `빈 문자열`을 넣을 경우 `GET /api/user/:userId` 로 요청되어 400을 받음

### RESPONSE

### 200

**Payload**

```tsx

{
	users : [
		{
			user_id: number;
			nickname: string;
			profile_url: string;
			relationWithMe : 'friend' | 'block' | 'none';
		},
		...
]
}
```

### 400

- ⚠️ 검색할 사용자 이름 부분은 `빈 문자열`을 넣을 경우 `GET /api/user/:userId` 로 요청되어 400을 받음

### 401

- 로그인 세션이 아님

**추가로 아래 Message를 담은 오류가 올 수 있음**

- ******************Message:****************** `invalid user (session is not valid)`
    - 해당 에러가 나올 경우, 세션은 살아있는데 유저가 삭제된 상태일 가능성이 높음.