### PR TITLE
[back] fix:  user_relation api 명세에 맞게 변경

### DIFF
--- a/backend/src/models/user/api/dtos/getUserRelationRes.dto.ts
+++ b/backend/src/models/user/api/dtos/getUserRelationRes.dto.ts
@@ -1,5 +1,10 @@
-import { UserRelationDto } from './userRelation.dto';
+export class UserRelationAndInfo {
+  target_id: number;
+  status: string;
+  nickname: string;
+  profile_url: string;
+}
 
 export class GetUserRelationResDto {
-  relations: UserRelationDto[];
+  relations: UserRelationAndInfo[];
 }

--- a/backend/src/models/user/api/services/userRelation.service.ts
+++ b/backend/src/models/user/api/services/userRelation.service.ts
@@ -10,14 +10,24 @@ export class UserRelationService {
   constructor(@InjectRepository(UserRelation) private userRelationRepository: Repository<UserRelation>) {}
 
   async getUserAllRelation(userId: number): Promise<GetUserRelationResDto> {
-    const relations: UserRelationDto[] = await this.userRelationRepository.find({
+    const relations: UserRelation[] = await this.userRelationRepository.find({
       where: {
         user_id: userId,
         status: Not(RelationStatus.NONE),
       },
       select: ['target_id', 'status'],
+      relations: ['target'],
     });
-    return { relations: relations };
+    return {
+      relations: relations.map((relation: UserRelation) => {
+        return {
+          target_id: relation.target_id,
+          status: relation.status,
+          nickname: relation.target.nickname,
+          profile_url: relation.target.profile_url,
+        };
+      }),
+    };
   }
 
   async getUserFriendRelation(userId: number): Promise<GetUserRelationResDto> {
@@ -27,8 +37,18 @@ export class UserRelationService {
         status: RelationStatus.FRIEND,
       },
       select: ['target_id', 'status'],
+      relations: ['target'],
     });
-    return { relations: relations };
+    return {
+      relations: relations.map((relation: UserRelation) => {
+        return {
+          target_id: relation.target_id,
+          status: relation.status,
+          nickname: relation.target.nickname,
+          profile_url: relation.target.profile_url,
+        };
+      }),
+    };
   }
 
   async getUserBlockRelation(userId: number): Promise<GetUserRelationResDto> {
@@ -38,8 +58,18 @@ export class UserRelationService {
         status: RelationStatus.BLOCK,
       },
       select: ['target_id', 'status'],
+      relations: ['target'],
     });
-    return { relations: relations };
+    return {
+      relations: relations.map((relation: UserRelation) => {
+        return {
+          target_id: relation.target_id,
+          status: relation.status,
+          nickname: relation.target.nickname,
+          profile_url: relation.target.profile_url,
+        };
+      }),
+    };
   }
 
   async updateUserRelation(userId: number, payload: UpdateUserRelationReqDto): Promise<UpdateUserRelationResDto> {

--- a/backend/src/models/user/api/services/userRelation.service.ts
+++ b/backend/src/models/user/api/services/userRelation.service.ts
@@ -1,6 +1,6 @@
 import { InjectRepository } from '@nestjs/typeorm';
 import { UserRelation } from '../../entities';
-import { Not, Repository } from 'typeorm';
+import { Not, QueryFailedError, Repository } from 'typeorm';
 import { BadRequestException, Injectable } from '@nestjs/common';
 import { GetUserRelationResDto, UpdateUserRelationReqDto, UpdateUserRelationResDto, UserRelationDto } from '../dtos';
 import { RelationStatus } from '../../../../common/enums/relationStatus.enum';
@@ -76,10 +76,16 @@ export class UserRelationService {
     if (payload.target_id === userId) {
       throw new BadRequestException('본인과의 관계는 설정 불가능합니다.');
     }
-    return await this.userRelationRepository.save({
-      user_id: userId,
-      target_id: payload.target_id,
-      status: payload.status,
-    });
+    try {
+      return await this.userRelationRepository.save({
+        user_id: userId,
+        target_id: payload.target_id,
+        status: payload.status,
+      });
+    } catch (e) {
+      if (e instanceof QueryFailedError) {
+        throw new BadRequestException('없는 유저와의 관계는 불가능합니다.');
+      }
+    }
   }
 }


### PR DESCRIPTION
# /api/user/user_rleation

## Method

`PUT`

## Authentication

- 로그인 세션

## 역할

- 유저와 유저 사이의 관계 조정

## REQUEST

- `PUT /user_relation`

### payload

```tsx
{
  target_id : number, // target user
  status: 'friend' | 'block'
}
```

## RESPONSE

### 200

해당 리퀘스트 결과 반환

```tsx
{
  target_id : number, // target user
  status: 'friend' | 'block' | 'none' // 대소문자 주의
}
```

### 400

- 본인에게 요청한 경우
    - `본인과의 관계는 설정 불가능합니다.`
- 없는 유저에게 요청한 경우
    - `없는 유저와의 관계는 불가능합니다.`