### PR TITLE
[back] fix: notify socket, notifier & feat : SocketMapService

### DIFF
--- a/backend/src/models/notifier/notifier.module.ts
+++ b/backend/src/models/notifier/notifier.module.ts
@@ -5,10 +5,11 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../user/entities';
 import { ChatChannel } from '../chat/entities';
 import { NotifierGateway } from './notifier.gateway';
+import { SocketMapService } from '../../providers/redis/socketMap.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User, ChatChannel])],
-  providers: [Notifier, NotifierService, NotifierGateway],
+  providers: [Notifier, NotifierService, NotifierGateway, SocketMapService],
   exports: [Notifier, NotifierService, NotifierGateway],
 })
 export class NotifierModule {}

--- a/backend/src/models/notifier/services/notifier.service.ts
+++ b/backend/src/models/notifier/services/notifier.service.ts
@@ -13,9 +13,9 @@ export class NotifierService {
   }
 
   async notifyToUser(server: Server, userId: number, event: string, data: any) {
-    const userSockets: string = await this.redisClient.get(`${userId}`);
+    const userSockets = await this.redisClient.hgetall(`${userId}`);
     if (!userSockets) return;
-    const { socketId } = JSON.parse(userSockets);
+    const socketId = userSockets.notify;
     if (!socketId) return;
     const notifyNamespace: Namespace = await server.of('/notify');
 

--- a/backend/src/models/notifier/services/notifier.service.ts
+++ b/backend/src/models/notifier/services/notifier.service.ts
@@ -1,19 +1,15 @@
 import { Injectable, Logger } from '@nestjs/common';
 import { Namespace, Server } from 'socket.io';
-import { Redis } from 'ioredis';
-import { RedisService } from '@liaoliaots/nestjs-redis';
+import { SocketMapService } from '../../../providers/redis/socketMap.service';
 
 @Injectable()
 export class NotifierService {
-  private readonly redisClient: Redis;
   private readonly logger = new Logger('NotifierService');
 
-  constructor(private readonly redisService: RedisService) {
-    this.redisClient = redisService.getClient();
-  }
+  constructor(private readonly socketMapService: SocketMapService) {}
 
   async notifyToUser(server: Server, userId: number, event: string, data: any) {
-    const userSockets = await this.redisClient.hgetall(`${userId}`);
+    const userSockets = await this.socketMapService.getUserSockets(userId);
     if (!userSockets) return;
     const socketId = userSockets.notify;
     if (!socketId) return;

--- a/backend/src/models/notifySocket/socket/dto/userSockets.dto.ts
+++ b/backend/src/models/notifySocket/socket/dto/userSockets.dto.ts
@@ -1,3 +1,5 @@
 export class UserSocketsDto {
-  socketId: string;
+  notify: string;
+  chat: string;
+  game: string;
 }

--- a/backend/src/models/notifySocket/socket/notifySocket.gateway.ts
+++ b/backend/src/models/notifySocket/socket/notifySocket.gateway.ts
@@ -5,10 +5,10 @@ import {
   WebSocketGateway,
   WebSocketServer,
 } from '@nestjs/websockets';
-import { UseFilters } from '@nestjs/common';
+import { Logger, UseFilters } from '@nestjs/common';
 import { NotifySocketService } from './services';
 import { WsExceptionFilter } from '../../../common/filters/socket/wsException.filter';
-import { Server } from 'socket.io';
+import { Server, Socket } from 'socket.io';
 
 /**
  * NotifyGateway 의 경우 Entriy Point 로 사용하지 않기 때문에 특별한 행동을 하지 않습니다.
@@ -19,12 +19,22 @@ import { Server } from 'socket.io';
 @WebSocketGateway({ namespace: 'notify' })
 export class NotifySocketGateway implements OnGatewayConnection, OnGatewayDisconnect {
   constructor(private readonly notifyService: NotifySocketService) {}
+  private readonly logger = new Logger('NotifySocketGateway');
   @WebSocketServer()
   server: Server;
-  async handleConnection(@ConnectedSocket() socket) {
-    await this.notifyService.connect(socket);
+  async handleConnection(@ConnectedSocket() socket: Socket) {
+    try {
+      await this.notifyService.connect(socket);
+    } catch (e) {
+      this.logger.error(`${e} on connecting`);
+      socket.disconnect();
+    }
   }
-  async handleDisconnect(@ConnectedSocket() socket) {
-    await this.notifyService.disconnect(socket);
+  async handleDisconnect(@ConnectedSocket() socket: Socket) {
+    try {
+      await this.notifyService.disconnect(socket);
+    } catch (e) {
+      this.logger.error(`${e} on disconnecting`);
+    }
   }
 }

--- a/backend/src/models/notifySocket/socket/notifySocket.module.ts
+++ b/backend/src/models/notifySocket/socket/notifySocket.module.ts
@@ -4,9 +4,10 @@ import { NotifySocketGateway } from './notifySocket.gateway';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { User } from '../../user/entities';
 import { NotifierModule } from '../../notifier/notifier.module';
+import { SocketMapService } from '../../../providers/redis/socketMap.service';
 
 @Module({
   imports: [TypeOrmModule.forFeature([User]), NotifierModule],
-  providers: [NotifySocketGateway, NotifySocketService],
+  providers: [NotifySocketGateway, NotifySocketService, SocketMapService],
 })
 export class NotifySocketModule {}

--- a/backend/src/models/notifySocket/socket/services/notifySocket.service.ts
+++ b/backend/src/models/notifySocket/socket/services/notifySocket.service.ts
@@ -4,8 +4,6 @@ import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { User } from '../../../user/entities';
 import { UserStatusEnum } from '../../../../common/enums';
-import { WsException } from '@nestjs/websockets';
-import { UserSocketsDto } from '../dto/userSockets.dto';
 import { RedisService } from '@liaoliaots/nestjs-redis';
 import { Redis } from 'ioredis';
 import { Notifier } from '../../../notifier/services/notifier.class';
@@ -14,7 +12,7 @@ import { ChannelEnum } from '../../../notifier/enums/channel.enum';
 
 @Injectable()
 export class NotifySocketService {
-  private readonly logger = new Logger('NotifyGateway');
+  private readonly logger = new Logger('NotifySocketService');
   private readonly redisClient: Redis;
   constructor(
     private readonly redisService: RedisService,
@@ -26,41 +24,16 @@ export class NotifySocketService {
 
   async connect(socket: Socket) {
     const { user_id } = socket.handshake.query;
-
-    // check handshake is valid
+    if (!user_id) throw new Error('user_id is required');
     // 해당 부분에서 jwt validation 필요합니다.
-    if (!user_id) {
-      this.logger.warn(`Invalid user_id on connecting with [${socket.id}]`);
-      socket.disconnect();
-      return;
-    } else {
-      socket.data.user_id = user_id;
-    }
+
+    const userId: string = user_id.toString();
+    socket.data.user = userId;
     // update in db
-    try {
-      await this.userRepository.update({ user_id: +user_id }, { status: UserStatusEnum.ONLINE });
-    } catch (e) {
-      this.logger.error(`${e}, disconnecting...`);
-      socket.disconnect();
-      return;
-    }
-
+    await this.userRepository.update({ user_id: +userId }, { status: UserStatusEnum.ONLINE });
     // update socket information in redis
-    const userSockets: string = await this.redisClient.get(user_id.toString());
-    let jsonUserSockets: UserSocketsDto;
-    if (userSockets) {
-      jsonUserSockets = JSON.parse(userSockets);
-      jsonUserSockets.socketId = socket.id;
-      this.redisClient.set(user_id.toString(), JSON.stringify(jsonUserSockets));
-    } else {
-      jsonUserSockets = {
-        socketId: socket.id,
-      };
-      this.redisClient.set(user_id.toString(), JSON.stringify(jsonUserSockets));
-    }
-    this.logger.log(`connect with socket id: ${socket.id}`);
-    socket.emit('message', 'connected');
-
+    await this.redisClient.hmset(userId, 'notify', socket.id);
+    await this.redisClient.set(`socketToUser:${socket.id}`, userId);
     // notify to user status that subscribed to this user
     const userUpdated: User = await this.userRepository.findOne({
       where: { user_id: +user_id },
@@ -72,27 +45,19 @@ export class NotifySocketService {
       },
     });
     await this.notifier.notify(+user_id, 'user_status', userUpdated, TopicEnum.USER, ChannelEnum.ALL, 0);
+    socket.emit('message', 'connected');
+    this.logger.log(`user ${user_id} connect with socket id: ${socket.id}`);
   }
 
   async disconnect(socket: Socket) {
-    const { user_id } = socket.data;
-    if (!user_id) throw new WsException('user_id is required');
+    const user_id = socket.data.user;
+    if (!user_id) throw new Error('user_id is required');
+    const userId: string = user_id.toString();
     // update in db
-    try {
-      await this.userRepository.update(user_id, { status: UserStatusEnum.OFFLINE });
-    } catch (e) {
-      this.logger.error(`${e} on ${socket.id}`);
-      this.logger.log(`disconnect with socket id: ${socket.id}`);
-      return;
-    }
-    // update in redis
-    const userSockets: string = await this.redisClient.get(user_id.toString());
-    if (userSockets) {
-      this.redisClient.del(user_id.toString());
-    } else {
-      this.logger.error(`${socket.id} is not exist in Redis`);
-    }
-    this.logger.log(`disconnect with socket id: ${socket.id}`);
+    await this.userRepository.update(user_id, { status: UserStatusEnum.OFFLINE });
+    // delete socket information in redis
+    await this.redisClient.hdel(userId, 'notify');
+    await this.redisClient.del(`socketToUser:${socket.id}`);
     // notify to user status that subscribed to this user
     const userUpdated: User = await this.userRepository.findOne({
       where: { user_id: +user_id },
@@ -104,5 +69,6 @@ export class NotifySocketService {
       },
     });
     await this.notifier.notify(+user_id, 'user_status', userUpdated, TopicEnum.USER, ChannelEnum.ALL, 0);
+    this.logger.log(`user ${user_id} disconnect with socket id: ${socket.id}`);
   }
 }

--- a/backend/src/providers/redis/provider.module.ts
+++ b/backend/src/providers/redis/provider.module.ts
@@ -14,7 +14,7 @@ import { RedisModule } from '@liaoliaots/nestjs-redis';
           port: redisConfigService.port,
           password: redisConfigService.password,
           db: redisConfigService.socketDB,
-          keyPrefix: 'socket',
+          keyPrefix: 'socket::',
           lazyConnect: true, // 서버 첫 시작에서 connect 가 꼬이는 과정을 방지함.
         },
       }),

--- a/backend/src/providers/redis/socketMap.service.ts
+++ b/backend/src/providers/redis/socketMap.service.ts
@@ -1,0 +1,87 @@
+import { Injectable } from '@nestjs/common';
+import { RedisService } from '@liaoliaots/nestjs-redis';
+
+interface SocketMap {
+  [key: string]: string;
+}
+
+@Injectable()
+export class SocketMapService {
+  private readonly redisClient;
+  constructor(private redisService: RedisService) {
+    this.redisClient = this.redisService.getClient();
+  }
+
+  async getUserSockets(userId: number): Promise<SocketMap | null> {
+    return await this.getSocketsFromUserId(userId);
+  }
+
+  async getSocketUser(socketId: string): Promise<string | null> {
+    return await this.getUserIdFromSocketId(socketId);
+  }
+
+  async setUserSocket(userId: number, socketType: string, socketId: string) {
+    await this.setSocketIdToUserId(userId, socketType, socketId);
+    await this.setUserIdToSocketId(socketId, userId);
+  }
+
+  async deleteUserSocket(userId: number, socketType: string) {
+    const socketId = await this.redisClient.hget(`${userId}`, socketType);
+    if (!socketId) return;
+    await this.removeUserIdFromSocketId(socketId);
+    await this.removeSocketIdFromUserId(userId, socketType);
+  }
+
+  /**
+   * Set socketId to userId
+   *
+   * it will be set like this in redis:
+   *
+   * userId : {
+   *   socketType: socketId
+   * }
+   * @param userId
+   * @param socketType
+   * @param socketId
+   */
+  private async setSocketIdToUserId(userId: number, socketType: string, socketId: string) {
+    return await this.redisClient.hmset(`${userId}`, socketType, socketId);
+  }
+
+  /**
+   * returns { socketType: socketId, ... }
+   * @param userId
+   */
+  private async getSocketsFromUserId(userId: number): Promise<SocketMap | null> {
+    const result = await this.redisClient.hgetall(`${userId}`);
+    if (Object.keys(result).length === 0) return null;
+    return result;
+  }
+
+  /**
+   * Set socketId to userId
+   * it will be set like this in redis:
+   * `socketToUser:${socketId}` : `${userId}`
+   * @param socketId
+   * @param userId
+   */
+  private async setUserIdToSocketId(socketId: string, userId: number) {
+    await this.redisClient.set(`socketToUser:${socketId}`, userId);
+  }
+
+  /**
+   * will return userId
+   * @param socketId
+   */
+  private async getUserIdFromSocketId(socketId: string): Promise<string | null> {
+    return await this.redisClient.get(`socketToUser:${socketId}`);
+  }
+
+  private async removeSocketIdFromUserId(userId: number, socketType: string) {
+    await this.redisClient.hdel(`${userId}`, socketType);
+  }
+
+  private async removeUserIdFromSocketId(socketId: string) {
+    await this.redisClient.del(`socketToUser:${socketId}`);
+  }
+}


### PR DESCRIPTION
## fix
### 문제 1
- connect, disconnect 시에 throw 되는 것들을 안잡고 있었음. 이를 gateway 단에서 try catch 함
### 문제 2
- @kyu-baek 님이 지적해주셨듯, gateway namespace별로 따로 소켓이 연결됨
- redis에 socket id 하나만 할당하면 모두가 사용할 수 없음.
- redis에서 그냥 string으로 json 저장하는 바람에 소켓 여러개가 한꺼번에 바꾸려고 하는 경우 충돌 문제가 있었는데, `hset`, `hget` 을 이용해서 해결함
## enhancement
- redis에서 user-socket map을 들고오는게 조금 불편한 것 같아서 추상화된 `SocketMapService` 추가함
### SocketMapService
- `getUserSockets(userId: number)`
  - `userId : { socket_type : socketID, ... }` 의 형태의 오브젝트 반환
  - 유저 아이디를 통해서 `socket id` 를 획득할 수 있다.
- `getSocketUser(socketId: string)`
  - `socket id` 를 통해서 할당된 `user id` 획득
- `setUserSocket(userId: number, socketType: string, socketId: string)`
  - `userId : socketIDs` mapping을 함
  - key `userId`
  - value
    ```jsonc
    {
      socketType: socketId,
      ...
    }
    ```
  - 위와 같은 형태로 redis에 저장됨
  - 그리고 자동으로 `socket id` 에 대응되는 user id mapping도 진행됨 (`socketID : userID`)
- `deleteUserSocket(userId: number, socketType: string)`
  - `userID : socketID` 매핑 해제, `socketId: userID `매핑 해제

## 테스트 된 부분
- 연결/연결해제 에서 throw 로 서버 안뻗는거 확인
- redis에 정상적으로 값 업데이트되는거 확인
- notifier 가 redis와 연동되어 socket id를 올바르게 찾는 것 확인
- notify socket connect / disconnect 와 함께 접속해있는 chat channel에 유저 정보 업데이트가 전달되는 것 확인

## 해당 PR 머지후 해주셔야할 것
- 각 소켓 연결에서 user id - socket id 가 활용되는 경우 반드시 SocketMapService를 활용하여 socket id 를 읽기,쓰기 해야함
- @kyu-baek 님의 경우 `chat gateway`에서 namespace을 `chat`으로 수정 부탁드립니다. (지금 아무것도 지정안됨)