### PR TITLE
[back] FEAT:  game socket connection guard

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,3 @@
 .vscode/
 */.env
 .env
-dockerlight_test
-frontend
-TestBed

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 .vscode/
 */.env
 .env
+dockerlight_test
+frontend
+TestBed

--- a/backend/src/models/game/entities/match.entity.ts
+++ b/backend/src/models/game/entities/match.entity.ts
@@ -24,7 +24,7 @@ export class Match {
   @Column({ type: 'int8', default: 0 })
   right_score: number;
 
-  @Factory((faker) => faker.datatype.number({ min: 0, max: 100 }))
+  @Factory((faker) => faker.datatype.number({ min: 1, max: 100 }))
   @Column({ type: 'int', default: 0 })
   left_player: number;
 
@@ -32,7 +32,7 @@ export class Match {
   @JoinColumn({ name: 'left_player' })
   lPlayer: User;
 
-  @Factory((faker) => faker.datatype.number({ min: 0, max: 100 }))
+  @Factory((faker) => faker.datatype.number({ min: 1, max: 100 }))
   @Column({ type: 'int' })
   right_player: number;
   

--- a/backend/src/models/game/enum/GameEnum.ts
+++ b/backend/src/models/game/enum/GameEnum.ts
@@ -17,6 +17,7 @@ export enum RoomType {
 export enum PlayerLocation {
 	RIGHT,
 	LEFT,
+  OBSERVER,
 }
 
 export enum InputEnum{

--- a/backend/src/models/game/gameData/MatchJoinData.ts
+++ b/backend/src/models/game/gameData/MatchJoinData.ts
@@ -1,14 +1,11 @@
 import { GameType, RoomType} from "../enum/GameEnum";
 
 interface MatchJoinInterface{
-  userId: number; // dataBase user id
 	roomType: RoomType; // 게임 참여 위치(채팅방, 랜덤매칭)
 	gameType: GameType; // 게임 모드(기본모드, 장애물이나 스킬이 존재하는 특별 모드)
 }
 
 export class MatchJoinData implements MatchJoinInterface {
-	public userId: number;
 	public roomType: RoomType;
 	public gameType: GameType;
-  
 }

--- a/backend/src/models/game/gameData/ScoreData.ts
+++ b/backend/src/models/game/gameData/ScoreData.ts
@@ -1,9 +1,9 @@
 interface ScoreInterface {
-  rightSocre : number; //오른쪽 플레이어 점수
+  rightScore : number; //오른쪽 플레이어 점수
   leftScore : number; //외쪽 플레이어 점수
 }
 
 export class ScoreData implements ScoreInterface {
-  public rightSocre: number = 0;
+  public rightScore: number = 0;
   public leftScore: number = 0;
 }

--- a/backend/src/models/game/simul/GameSimulator.ts
+++ b/backend/src/models/game/simul/GameSimulator.ts
@@ -57,7 +57,7 @@ export function step(
       simulator.ball.SetLinearVelocity(RandomVec2());
       BallSpeedCorrection(simulator.ball, BALL_SPEED);
       scoreData.leftScore = simulator.ball.GetUserData().player1_score;
-      scoreData.rightSocre = simulator.ball.GetUserData().player2_score;
+      scoreData.rightScore = simulator.ball.GetUserData().player2_score;
       server.to(gameId).emit('score', scoreData);
     }
     MovePeddle(simulator.user1);

--- a/backend/src/models/game/socket/game.gateway.ts
+++ b/backend/src/models/game/socket/game.gateway.ts
@@ -20,9 +20,9 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     private readonly logger : Logger,
   ){}
 
-  async handleConnection() {
+  async handleConnection(@ConnectedSocket() client : Socket) {
     //socket vaild check
-    console.log('socket connet');
+    this.logger.log(`${client.id} is connect game socket`);
   }
   //client가 창을 닫을 때 끊을 것 인지 게임 매칭을 나갈때 닫을 것인지에 따라 구현이 달라질듯
   //client가 게임 참가자인지 옵저버인지 구분해야함
@@ -40,9 +40,9 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       gameManager.simulator.matchInterrupt.isInterrupt = true;
       gameManager.simulator.matchInterrupt.sid = client.id;
       this.gameService.matchGiveUp(gameManager, client.id);
-      console.log('player disconnect and giveUp game')
+      this.logger.log(`${client.id} player disconnect and giveUp game`);
     }
-    console.log('socket disconnet');
+    this.logger.log(`${client.id} is disconnect game socket`);
   }
 
   //모드 맞는 방 찾아서 매칭하고 없으면 생성  
@@ -57,7 +57,7 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
       gameManager.createPlayer(client.id, matchJoinData.userId);
       this.gameService.socketJoinRoom(client, gameManager.gameId);
       this.gameRooms.set(gameManager.gameId, gameManager);
-      console.log('gameCreate', gameManager.gameId);
+      this.logger.log(`gameCreate ${gameManager.gameId}`);
     } else {
       gameManager.createPlayer(client.id, matchJoinData.userId);
       this.gameService.socketJoinRoom(client, gameManager.gameId);

--- a/backend/src/models/game/socket/game.module.ts
+++ b/backend/src/models/game/socket/game.module.ts
@@ -4,9 +4,20 @@ import { Match } from '../entities';
 import { GameGateway } from './game.gateway';
 import { GameService } from './services';
 import { GameDataMaker } from './services/game.data.maker';
-
+import { JwtModule } from '@nestjs/jwt';
+import { JwtConfigModule } from 'src/config/jwt/config.module';
+import { JwtConfigService } from 'src/config/jwt/config.service';
 @Module({
-  imports :[TypeOrmModule.forFeature([Match])],
+  imports :[
+    TypeOrmModule.forFeature([Match]),
+    JwtModule.registerAsync({
+      imports: [JwtConfigModule],
+      useFactory: async (jwtConfigService: JwtConfigService) => ({
+        secret: jwtConfigService.secret,
+        signOptions: { expiresIn: jwtConfigService.expiresIn, algorithm: 'HS256', issuer: '3DPong' },
+      }),
+      inject: [JwtConfigService],
+  })],
   providers : [
     GameGateway,
     GameService,

--- a/backend/src/models/game/socket/services/game.data.maker.ts
+++ b/backend/src/models/game/socket/services/game.data.maker.ts
@@ -16,6 +16,18 @@ export class GameDataMaker {
     return matchStartData;
   }
   
+  public makeObserverData(
+    gameManager : GameManager,
+  ) : OnSceneData {
+    const matchStartData : OnSceneData = new OnSceneData();
+
+    matchStartData.gameId = gameManager.gameId;
+    matchStartData.playerLocation = PlayerLocation.OBSERVER;
+    matchStartData.enemyUserId = undefined;
+    matchStartData.sceneData = this.makeObjectDatas(gameManager);
+    return matchStartData;
+  }
+
   public makeObjectDatas (
     gameManager : GameManager
   ) : ObjectData[] {

--- a/backend/src/models/game/socket/services/game.service.ts
+++ b/backend/src/models/game/socket/services/game.service.ts
@@ -73,6 +73,11 @@ export class GameService {
     server.to(player2sid).emit('onSceneReady', onSceneData2);
   }
   
+  public initObserver(gameManager : GameManager, server : Server, sid : string){
+    const onSceneData : OnSceneData = this.gameDataMaker.makeObserverData(gameManager);
+    server.to(sid).emit('onSceneReady', onSceneData);
+  }
+
   async createMatch(gameManager : GameManager){
     try {
       const newMatch = new Match();

--- a/backend/src/models/game/socket/services/game.service.ts
+++ b/backend/src/models/game/socket/services/game.service.ts
@@ -61,7 +61,7 @@ export class GameService {
 
   public gamePreheat(gameManager : GameManager, server : Server){
     gameManager.simulator = new GameSimulator(gameManager.player1, gameManager.player2, gameManager.gameType);
-    gameManager.renderDatas = this.initRenderDatas(gameManager);
+    gameManager.renderDatas = this.gameDataMaker.makeRenderDatas(gameManager);
     gameManager.scoreData = new ScoreData();
 
     const player1sid : string = gameManager.player1.sid;
@@ -71,10 +71,6 @@ export class GameService {
 
     server.to(player1sid).emit('onSceneReady', onSceneData1);
     server.to(player2sid).emit('onSceneReady', onSceneData2);
-  }
-
-  public initRenderDatas(gameManager : GameManager) : RenderData[] {
-    return this.gameDataMaker.makeRenderDatas(gameManager);
   }
   
   async createMatch(gameManager : GameManager){
@@ -90,5 +86,12 @@ export class GameService {
     } catch (error) {
       throw new InternalServerErrorException('DataBase save Error');
     }
+  }
+
+  public isGamePalyer(gameManager : GameManager, sid : string) : boolean {
+    if (gameManager.player1.sid == sid || gameManager.player2.sid == sid){
+      return true;
+    }
+    return false;
   }
 }


### PR DESCRIPTION
# 구현 사항
  - game socket에 jwt guard 적용해서 토큰이 없는채로 서버에 socket connet 하려는 시도 차단 
  - 기존에는 관전을 하게 되면 render Data만 보내줬는데 처음에 object들 생성해주기 위한 데이터를 먼저 보내주고 render Data를 보내야함
  - match seeder 오류 수정