### PR TITLE
[back] FIX: 로그인 과정에서 중복 로그인으로 인한 에러 처리

### DIFF
--- a/backend/src/auth/api/auth.controller.ts
+++ b/backend/src/auth/api/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post, Res, UseGuards } from '@nestjs/common';
+import { Body, Controller, Get, Post, Res, UnauthorizedException, UseGuards } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { User } from '../../models/user/entities';
 import { Repository } from 'typeorm';
@@ -27,7 +27,15 @@ export class AuthController {
   @UseGuards(FtGuard)
   @Get('/redirect/42')
   async ftRedirect(@GetGuardData() data: FtDataInterface, @Res() res: Response): Promise<void> {
-    return this.authService.redirect(data, res);
+    try {
+      return await this.authService.redirect(data, res);
+    } catch (e) {
+      if (e instanceof UnauthorizedException) {
+        res.redirect('/signin_duplicated');
+      } else {
+        res.redirect('/signin_fail');
+      }
+    }
   }
 
   // will be redirected to /

--- a/backend/src/common/filters/socket/socket.filter.ts
+++ b/backend/src/common/filters/socket/socket.filter.ts
@@ -11,8 +11,12 @@ export type ExceptionStatus =
   | 'InternalServerError';
 
 export class SocketException extends WsException {
+  status;
+  message;
   constructor(status: ExceptionStatus, message: string) {
     super({ status, message });
+    this.status = status;
+    this.message = message;
   }
 }
 
@@ -20,11 +24,10 @@ export class SocketException extends WsException {
 export class SocketExceptionFilter extends BaseWsExceptionFilter {
   catch(exception: SocketException, host: ArgumentsHost) {
     const socket: Socket = host.getArgByIndex(0);
-    const error = exception.getError();
 
     socket.emit('error', {
-      status: `${Object.values(error)[0]}`,
-      message: `${Object.values(error)[1]}`,
+      status: exception.status,
+      message: exception.message,
     });
   }
 }

--- a/backend/src/common/filters/socket/socket.filter.ts
+++ b/backend/src/common/filters/socket/socket.filter.ts
@@ -11,8 +11,8 @@ export type ExceptionStatus =
   | 'InternalServerError';
 
 export class SocketException extends WsException {
-  status;
-  message;
+  status: string;
+  message: string;
   constructor(status: ExceptionStatus, message: string) {
     super({ status, message });
     this.status = status;

--- a/backend/src/providers/redis/provider.module.ts
+++ b/backend/src/providers/redis/provider.module.ts
@@ -14,7 +14,7 @@ import { RedisModule } from '@liaoliaots/nestjs-redis';
           port: redisConfigService.port,
           password: redisConfigService.password,
           db: redisConfigService.socketDB,
-          keyPrefix: 'socket::',
+          keyPrefix: 'SocketDB:',
           lazyConnect: true, // 서버 첫 시작에서 connect 가 꼬이는 과정을 방지함.
         },
       }),

--- a/backend/src/providers/redis/socketMap.service.ts
+++ b/backend/src/providers/redis/socketMap.service.ts
@@ -45,7 +45,7 @@ export class SocketMapService {
    * @param socketId
    */
   private async setSocketIdToUserId(userId: number, socketType: string, socketId: string) {
-    return await this.redisClient.hmset(`${userId}`, socketType, socketId);
+    return await this.redisClient.hmset(`user:${userId}`, socketType, socketId);
   }
 
   /**
@@ -53,7 +53,7 @@ export class SocketMapService {
    * @param userId
    */
   private async getSocketsFromUserId(userId: number): Promise<SocketMap | null> {
-    const result = await this.redisClient.hgetall(`${userId}`);
+    const result = await this.redisClient.hgetall(`user:${userId}`);
     if (Object.keys(result).length === 0) return null;
     return result;
   }
@@ -66,7 +66,7 @@ export class SocketMapService {
    * @param userId
    */
   private async setUserIdToSocketId(socketId: string, userId: number) {
-    await this.redisClient.set(`socketToUser:${socketId}`, userId);
+    await this.redisClient.set(`socket:${socketId}`, userId);
   }
 
   /**
@@ -74,14 +74,14 @@ export class SocketMapService {
    * @param socketId
    */
   private async getUserIdFromSocketId(socketId: string): Promise<string | null> {
-    return await this.redisClient.get(`socketToUser:${socketId}`);
+    return await this.redisClient.get(`socket:${socketId}`);
   }
 
   private async removeSocketIdFromUserId(userId: number, socketType: string) {
-    await this.redisClient.hdel(`${userId}`, socketType);
+    await this.redisClient.hdel(`user:${userId}`, socketType);
   }
 
   private async removeUserIdFromSocketId(socketId: string) {
-    await this.redisClient.del(`socketToUser:${socketId}`);
+    await this.redisClient.del(`socket:${socketId}`);
   }
 }


### PR DESCRIPTION
#179 
# [fix: 로그인 과정 에러처리](https://github.com/3DPong/transcendence/commit/d7e4383a4abe1ce8a5d978251b1d23b0478d31c8)
## fix: service.redirect 쪽에서 await 없어서 발생한 에러처리
- controller 에서 async 함수를 await 하지 않아 에러 발생 시 원하는바대로 핸들링되지 않았음.
## fix: 리다이렉트시 401 이 나오면 처리 안되는 문제 해결
- 리다이렉트 결과가 401이 되면, 프론트 입장에서 처리가 불가능하여, 적절한 경로 `/singin_duplicate` 로 리다이렉트함
# [fix: 소켓 연결 기반 온라인 상태 체크](https://github.com/3DPong/transcendence/commit/f234aa387531b1f1c90c77164aac2dc7d05b8fc4)
- DB 기준이 아닌 실제 연결된 소켓이 있는가를 기준으로 처리함.
- 해당 부분으로 인해서 failure로 인한 서버 다운 시 redis에 정보가 남아 온라인 상태로 유지될 수 있다는 문제가 있음.
- 주기적으로 연결되있다고 되어있는 소켓들에게 heartbeat 체크를 해서 상태를 업데이트해야할 것 같음
## refactor: redis key prefix 수정
- socket:: 으로 된거 SocketDB: 로 수정
- 조금 불명확했던 prefix, key 이름들 변경
## update: socket filter, exception 에서 status, message 사용할 수 있도록 변경
- SocketException에서 status, message 접근이 되지 않아 출력하는 과정이 불편했던 부분 수정