### PR TITLE
[back] FIX: user relation status

### DIFF
--- a/backend/src/models/user/api/dtos/getUserRelationRes.dto.ts
+++ b/backend/src/models/user/api/dtos/getUserRelationRes.dto.ts
@@ -1,8 +1,12 @@
+import { UserStatusEnum } from '../../../../common/enums';
+import { RelationStatus } from '../../../../common/enums/relationStatus.enum';
+
 export class UserRelationAndInfo {
   target_id: number;
-  status: string;
   nickname: string;
   profile_url: string;
+  relation: RelationStatus;
+  status: UserStatusEnum;
 }
 
 export class GetUserRelationResDto {


### PR DESCRIPTION
# [fix: user relation 을 가져올 때 해당 유저의 온라인 상태 첨부](https://github.com/3DPong/transcendence/commit/1b69c9e4564e4648b44d1c2628ad0a7c706b457f)
- 프론트측에서 유저간의 관계 획득과 함께 유저의 상태를 함께 요구함
```jsonc
// RESPONSE
{
  relations : [
      {
        target_id : number, // target user
				nickname: string;
			  profile_url: string;
        relation: 'friend' | 'block' | 'none';
				status: userStatus; // enum
      }
    ...
  ]
}
``` 
## refactor: 중복되는 코드 함수화 (UserRelationService.getUserRelations)
- 중복되어 사용되는 코드가 있어, 해당 부분을 하나의 함수로 통일함
