### PR TITLE
[front] chat 초대메시지 수정

### DIFF
--- a/frontend/src/components/Organism/Game/GameStartButton.tsx
+++ b/frontend/src/components/Organism/Game/GameStartButton.tsx
@@ -97,13 +97,23 @@ export default function GameMatchingDialog({
     if (inviteGameId) {
       handleModeSelectDialogClose(); // 모드 선택 종료.
       handleMatchingDialogOpen(); // 매칭 시작.
+
+      const matchJoinData: gameType.InvitedJoinData = {
+        gameId: inviteGameId,
+      };      
+
       if (isObserve) {
         console.log('observe 로 들어온 사람');
-        gameSocket.emit('observeJoin', JSON.stringify({ gameId: inviteGameId }));
+        gameSocket.emit('observeJoin', matchJoinData);
       }
       else {
+        // const matchJoinData: gameType.ChatJoinData = {
+        //   gameId: inviteGameId,
+        //   roomType: gameType.roomType.chat,
+        //   gameType: gameType.gameType.normal,
+        // };
         console.log('플레이어로 들어온 사람');
-        gameSocket.emit('chatJoin', JSON.stringify({ gameId: inviteGameId }));
+        gameSocket.emit('chatJoin', matchJoinData);
       }
     }
   }, [inviteGameId, gameSocket])

--- a/frontend/src/components/Organism/Home/Controller/Controller.tsx
+++ b/frontend/src/components/Organism/Home/Controller/Controller.tsx
@@ -107,7 +107,7 @@ export default function Controller() {
     gameSocket.on('onGameInvite', (data) => {
       const inviteMessage = JSON.stringify({
         gameId: data.gameId,
-        gameMode: data.gameMode || 'normal',
+        gameMode: data.gameType ? 'special' : 'normal',
       });
       if (chatSocket)
         chatSocket.emit('message-chat', { message: inviteMessage, type: 'game', channel_id: data.channelId });

--- a/frontend/src/types/game.ts
+++ b/frontend/src/types/game.ts
@@ -21,6 +21,10 @@ export interface ChatJoinData {
 	gameType: gameType; // 게임 모드
 }
 
+export interface InvitedJoinData {
+	gameId : string;
+}
+
 export interface Vec2 {
   x: number;
   y: number;


### PR DESCRIPTION
초대메시지 보내고 게임참여까지는 정상적으로 동작합니다.

게임에서 초대받은 사람은 플레이어임을 확인하지 못하는 버그가 있는데,  (서버에서 소켓에러 발생)
interface에서 임의로 게임타입, 룸타입을 줘도 같은에러가 발생해서 그냥 gameId만 전달하는 코드로 변경해뒀습니다.

초대메시지에서 mode가 정상적으로 보이지 않는 문제도 해결했습니다 