### PR TITLE
[back] key입력 오류, 유저 매치 전적 업데이트 추가

### DIFF
--- a/backend/src/models/game/dto/gameMatchUpdate.dto.ts
+++ b/backend/src/models/game/dto/gameMatchUpdate.dto.ts
@@ -1,0 +1,6 @@
+export interface GameMatchUpdateDto{
+  wins : number;
+  losses : number;
+  total : number;
+  level : number;
+}

--- a/backend/src/models/game/enum/GameEnv.ts
+++ b/backend/src/models/game/enum/GameEnv.ts
@@ -9,3 +9,4 @@ export const PADDLE_HEIGHT = 5;
 export const PADDLE_SPEED = 0.1;
 export const BALL_MAX_ANGLE = 0.785398 / 2; //45degree / 2
 export const BALL_PI = 3.14159; //180degree
+export const MAX_LEVEL = 100;

--- a/backend/src/models/game/simul/GameManager.ts
+++ b/backend/src/models/game/simul/GameManager.ts
@@ -83,6 +83,17 @@ export class GameManager {
           gameService.gameEndToClient(gameManager, server);
           clearInterval(timeEndCheck);
           await gameService
+            .updateMatchRecode(gameManager)
+            .catch(() =>{
+              this.logger.error(
+                `database update user_match failed : ${gameManager.gameId} ` +
+                  `player1 score: ${gameManager.player1.score} ` +
+                  `player2 score: ${gameManager.player2.score} ` +
+                  `player1 dbId: ${gameManager.player1.dbId} ` +
+                  `player2 dbId: ${gameManager.player2.dbId}`
+              );
+            })
+          await gameService
             .createMatch(gameManager)
             .then(() => {
               gameRooms.delete(gameManager.gameId);

--- a/backend/src/models/game/socket/game.gateway.ts
+++ b/backend/src/models/game/socket/game.gateway.ts
@@ -117,8 +117,6 @@ export class GameGateway implements OnGatewayConnection, OnGatewayDisconnect {
     const gameManager: GameManager = this.gameRooms.get(inputData.gameId);
     if (gameManager?.started && this.gameService.isGamePlayer(gameManager, client.id)) {
       gameManager.Keyboard(inputData.key, client.id);
-    } else {
-      throw new SocketException('BadRequest', 'player가 아닙니다.');
     }
   }
 

--- a/backend/src/models/game/socket/game.module.ts
+++ b/backend/src/models/game/socket/game.module.ts
@@ -7,10 +7,11 @@ import { GameDataMaker } from './services';
 import { JwtModule } from '@nestjs/jwt';
 import { JwtConfigModule } from 'src/config/jwt/config.module';
 import { JwtConfigService } from 'src/config/jwt/config.service';
+import { User } from 'src/models/user/entities';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Match]),
+    TypeOrmModule.forFeature([Match, User]),
     JwtModule.registerAsync({
       imports: [JwtConfigModule],
       useFactory: async (jwtConfigService: JwtConfigService) => ({

--- a/backend/src/models/game/socket/services/game.service.ts
+++ b/backend/src/models/game/socket/services/game.service.ts
@@ -54,7 +54,7 @@ export class GameService {
     }
     //gameId는 있는데 아래 get에서 실패하면 이미 끝난게임에 접근하려하므로 에러처리
     const gameManager: GameManager = gameRooms.get(chatJoinData.gameId);
-    if (gameManager.playerCount === 1) {
+    if (gameManager?.playerCount === 1) {
       return gameManager;
     }
     throw new SocketException('BadRequest', '사라진 방 입니다.');

--- a/backend/src/models/game/socket/services/game.service.ts
+++ b/backend/src/models/game/socket/services/game.service.ts
@@ -2,7 +2,7 @@ import { Injectable, InternalServerErrorException, Logger } from '@nestjs/common
 import { Socket } from 'socket.io';
 import { GameManager } from '../../simul/GameManager';
 import { GamePlayer } from '../../simul/GamePlayer';
-import { MATCH_SCORE } from '../../enum/GameEnv';
+import { MATCH_SCORE, MAX_LEVEL } from '../../enum/GameEnv';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Match } from '../../entities';
 import { Repository } from 'typeorm';
@@ -12,6 +12,8 @@ import { GameDataMaker } from './game.data.maker';
 import { GameSimulator } from '../../simul/GameSimulator';
 import { RoomType } from '../../enum/GameEnum';
 import { SocketException } from 'src/common/filters/socket/socket.filter';
+import { User } from 'src/models/user/entities';
+import { GameMatchUpdateDto } from '../../dto/gameMatchUpdate.dto';
 
 @Injectable()
 export class GameService {
@@ -19,8 +21,8 @@ export class GameService {
 
   constructor(
     private gameDataMaker: GameDataMaker,
-    @InjectRepository(Match)
-    private matchRepository: Repository<Match>
+    @InjectRepository(Match) private matchRepository: Repository<Match>,
+    @InjectRepository(User) private userRepository: Repository<User>,
   ) {
     this.logger = new Logger('gameService');
   }
@@ -94,32 +96,18 @@ export class GameService {
     server.to(sid).emit('onSceneReady', onSceneData);
   }
 
-  async createMatch(gameManager: GameManager) {
-    try {
-      const newMatch = new Match();
-      newMatch.game_type = gameManager.gameType;
-      newMatch.match_type = gameManager.gameRoomType;
-      newMatch.left_score = gameManager.player1.score;
-      newMatch.right_score = gameManager.player2.score;
-      newMatch.left_player = gameManager.player1.dbId;
-      newMatch.right_player = gameManager.player2.dbId;
-      await this.matchRepository.save(newMatch);
-    } catch (error) {
-      throw new InternalServerErrorException('DataBase save Error');
-    }
-  }
-
+  
   public isGamePlayer(gameManager: GameManager, sid: string): boolean {
     return gameManager.player1.sid == sid || gameManager.player2.sid == sid;
   }
-
+  
   //게임시작전
   //게임시작후
   //옵저빙 중에 탈출
   public gameExit(gameRooms: Map<string, GameManager>, client: Socket) {
     const gameManager: GameManager = gameRooms.get(client.data.gameId);
     if (!gameManager) return;
-
+    
     if (gameManager.playerCount === 1 && this.isGamePlayer(gameManager, client.id)) {
       gameRooms.delete(client.data.gameId);
       this.socketLeaveRoom(client, gameManager.gameId);
@@ -134,6 +122,64 @@ export class GameService {
         this.logger.log(`${client.id} observer leave game room`);
         this.socketLeaveRoom(client, gameManager.gameId);
       }
+    }
+  }
+  async createMatch(gameManager: GameManager) {
+    try {
+      const newMatch = new Match();
+      newMatch.game_type = gameManager.gameType;
+      newMatch.match_type = gameManager.gameRoomType;
+      newMatch.left_score = gameManager.player1.score;
+      newMatch.right_score = gameManager.player2.score;
+      newMatch.left_player = gameManager.player1.dbId;
+      newMatch.right_player = gameManager.player2.dbId;
+      await this.matchRepository.save(newMatch);
+    } catch (error) {
+      throw new InternalServerErrorException('DataBase save Error');
+    }
+  }
+  
+  async updateMatchRecode(gameManager: GameManager) {
+    const winerId : number = gameManager.player1.score > gameManager.player2.score ? 
+    gameManager.player1.dbId : gameManager.player2.dbId;
+    const loserId : number = gameManager.player1.score < gameManager.player2.score ? 
+    gameManager.player1.dbId : gameManager.player2.dbId;
+
+    const loser : User = await this.userRepository.findOne({
+      where : {
+        user_id : loserId
+      }
+    });
+
+    const winner : User = await this.userRepository.findOne({
+      where : {
+        user_id : winerId
+      }
+    });
+
+    const winnerData : GameMatchUpdateDto = {
+      wins : winner.wins + 1,
+      total : winner.total + 1,
+      losses : winner.losses,
+      level : Number((MAX_LEVEL * (1 - Math.pow(0.995, winner.total))).toFixed(2)),
+    }
+
+    const loserData : GameMatchUpdateDto = {
+      wins : loser.wins,
+      total : loser.total + 1,
+      losses : loser.losses + 1,
+      level :   Number((MAX_LEVEL * (1 - Math.pow(0.995, loser.total))).toFixed(2)),
+    }
+    try {
+      await this.userRepository.update({user_id : winerId}, winnerData);
+    } catch (error) {
+      throw new InternalServerErrorException('DataBase save Error');
+    }
+
+    try {
+      await this.userRepository.update({user_id : loserId}, loserData);
+    } catch (error) {
+      throw new InternalServerErrorException('DataBase save Error');
     }
   }
 }


### PR DESCRIPTION
### 유저 매치 전적 업데이트 추가 해서 #200 close 하고 다시 pr 날렸습니다.

유저 만렙은 100으로 임시 설정 해놨고 레벨이 오르는 로직은 다음과 같습니다.
MAX_LEVEL * (1 - Math.pow(0.995, user.total) 아마 400판 정도하면 만렙을 달성할 것이고 로직은 slove.ac 참고했습니다. 