### PR TITLE
[back] level logic fix, 게임 매치 종료 순서 변경

### DIFF
--- a/backend/src/models/game/simul/GameManager.ts
+++ b/backend/src/models/game/simul/GameManager.ts
@@ -71,8 +71,8 @@ export class GameManager {
         server: Server
       ) => {
         if (
-          simulator.ball.GetUserData().player1_score === MATCH_SCORE ||
-          simulator.ball.GetUserData().player2_score === MATCH_SCORE ||
+          simulator.ball.GetUserData().player1_score >= MATCH_SCORE ||
+          simulator.ball.GetUserData().player2_score >= MATCH_SCORE ||
           simulator.matchInterrupt.isInterrupt
         ) {
           clearInterval(timeStep);
@@ -110,7 +110,7 @@ export class GameManager {
             gameRooms.delete(gameManager.gameId);
         }
       },
-      1000,
+      100,
       this.simulator,
       gameRooms,
       this,

--- a/backend/src/models/game/simul/GameManager.ts
+++ b/backend/src/models/game/simul/GameManager.ts
@@ -76,12 +76,12 @@ export class GameManager {
           simulator.matchInterrupt.isInterrupt
         ) {
           clearInterval(timeStep);
+          clearInterval(timeEndCheck);
+          
           if (!simulator.matchInterrupt.isInterrupt) {
             gameManager.player1.score = simulator.ball.GetUserData().player1_score;
             gameManager.player2.score = simulator.ball.GetUserData().player2_score;
           }
-          gameService.gameEndToClient(gameManager, server);
-          clearInterval(timeEndCheck);
           await gameService
             .updateMatchRecode(gameManager)
             .catch(() =>{
@@ -95,11 +95,7 @@ export class GameManager {
             })
           await gameService
             .createMatch(gameManager)
-            .then(() => {
-              gameRooms.delete(gameManager.gameId);
-            })
             .catch(() => {
-              gameRooms.delete(gameManager.gameId);
               this.logger.error(
                 `database save match failed : ${gameManager.gameId} ` +
                   `gameType: ${gameManager.gameType} ` +
@@ -110,6 +106,8 @@ export class GameManager {
                   `player2 dbId: ${gameManager.player2.dbId}`
               );
             });
+            gameService.gameEndToClient(gameManager, server);
+            gameRooms.delete(gameManager.gameId);
         }
       },
       1000,

--- a/backend/src/models/game/socket/services/game.service.ts
+++ b/backend/src/models/game/socket/services/game.service.ts
@@ -112,7 +112,10 @@ export class GameService {
       gameRooms.delete(client.data.gameId);
       this.socketLeaveRoom(client, gameManager.gameId);
       this.logger.log(`${client.id} is disconnect game socket and delete ${gameManager.gameId}`);
-    } else if (gameManager.playerCount === 2 && gameManager.simulator.matchInterrupt.isInterrupt === false) {
+    } else if (
+      gameManager.playerCount === 2 && 
+      gameManager.simulator.matchInterrupt.isInterrupt === false
+    ) {
       if (this.isGamePlayer(gameManager, client.id)) {
         //player
         this.matchGiveUp(gameManager, client.id);
@@ -161,14 +164,14 @@ export class GameService {
       wins : winner.wins + 1,
       total : winner.total + 1,
       losses : winner.losses,
-      level : Number((MAX_LEVEL * (1 - Math.pow(0.995, winner.total))).toFixed(2)),
+      level : Number((MAX_LEVEL * (1 - Math.pow(0.995, winner.total + 1))).toFixed(2)),
     }
 
     const loserData : GameMatchUpdateDto = {
       wins : loser.wins,
       total : loser.total + 1,
       losses : loser.losses + 1,
-      level :   Number((MAX_LEVEL * (1 - Math.pow(0.995, loser.total))).toFixed(2)),
+      level : Number((MAX_LEVEL * (1 - Math.pow(0.995, loser.total + 1))).toFixed(2)),
     }
     try {
       await this.userRepository.update({user_id : winerId}, winnerData);


### PR DESCRIPTION
1. game이 끝났다는 것을 client한테 먼저 알리면 interrupt발생해서 서버에서 먼저 정리한뒤 client에서 알리는 것으로 변경
2. level up을 할때 방금 종료된 판을 고려해서 level을 올려줘야 하는데 반영 안됐던 부분 수정